### PR TITLE
Add scenario presets with persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,6 +239,10 @@
             <div style="padding: 25px; height: calc(100vh - 250px); overflow-y: auto; min-height: 700px;">
                 <div class="scenario-panel">
                     <h3>🎯 Анализ "Что если"</h3>
+                    <div class="scenario-select">
+                        <select id="scenario-select"></select>
+                        <button class="btn btn-primary" onclick="saveCurrentScenario()">Сохранить</button>
+                    </div>
                     <div class="scenario-controls">
                         <div class="scenario-slider">
                             <label>

--- a/script.js
+++ b/script.js
@@ -4,6 +4,22 @@
         // if (history[0]) history[0].profit = calculateMetrics(history[0].data).netProfit;
         let profitChart, funnelChart, channelsChart, scenarioChart, roiChart;
 
+        // Загрузка сценариев из localStorage или установка значений по умолчанию
+        let scenarios = JSON.parse(localStorage.getItem('scenarios') || 'null');
+        if (!scenarios) {
+            scenarios = [
+                {
+                    name: 'Базовый рост',
+                    values: { organicGrowth: 20, adBudget: 10, conversionChange: 5, checkChange: 0 }
+                },
+                {
+                    name: 'Экспансия',
+                    values: { organicGrowth: 100, adBudget: 100, conversionChange: 20, checkChange: 10 }
+                }
+            ];
+            localStorage.setItem('scenarios', JSON.stringify(scenarios));
+        }
+
         // Каналы и их настройки
         const channels = {
             habr: { name: 'Хабр', type: 'organic' },
@@ -481,6 +497,54 @@
             });
         }
 
+        function updateScenarioSelect() {
+            const select = document.getElementById('scenario-select');
+            if (!select) return;
+            select.innerHTML = scenarios.map((s, i) => `<option value="${i}">${s.name}</option>`).join('');
+        }
+
+        function loadSelectedScenario() {
+            const select = document.getElementById('scenario-select');
+            const idx = parseInt(select.value);
+            const scenario = scenarios[idx];
+            if (!scenario) return;
+
+            document.getElementById('organic-growth').value = scenario.values.organicGrowth;
+            document.getElementById('organic-growth-value').textContent = scenario.values.organicGrowth + '%';
+            document.getElementById('ad-budget').value = scenario.values.adBudget;
+            document.getElementById('ad-budget-value').textContent = scenario.values.adBudget + '%';
+            document.getElementById('conversion-change').value = scenario.values.conversionChange;
+            document.getElementById('conversion-change-value').textContent = scenario.values.conversionChange + '%';
+            document.getElementById('check-change').value = scenario.values.checkChange;
+            document.getElementById('check-change-value').textContent = scenario.values.checkChange + '%';
+
+            updateScenarios();
+        }
+
+        function saveCurrentScenario() {
+            const name = prompt('Название сценария');
+            if (!name) return;
+
+            const values = {
+                organicGrowth: parseFloat(document.getElementById('organic-growth').value) || 0,
+                adBudget: parseFloat(document.getElementById('ad-budget').value) || 0,
+                conversionChange: parseFloat(document.getElementById('conversion-change').value) || 0,
+                checkChange: parseFloat(document.getElementById('check-change').value) || 0
+            };
+
+            const existing = scenarios.find(s => s.name === name);
+            if (existing) {
+                existing.values = values;
+            } else {
+                scenarios.push({ name, values });
+            }
+
+            localStorage.setItem('scenarios', JSON.stringify(scenarios));
+            updateScenarioSelect();
+            const index = scenarios.findIndex(s => s.name === name);
+            document.getElementById('scenario-select').value = index;
+        }
+
         function switchTab(tabName) {
             document.querySelectorAll('.tab').forEach(tab => tab.classList.remove('active'));
             document.querySelectorAll('.tab-content').forEach(content => content.classList.remove('active'));
@@ -639,6 +703,9 @@
             updateScenarios();
         });
 
+        // Выбор сохраненного сценария
+        document.getElementById('scenario-select').addEventListener('change', loadSelectedScenario);
+
         // Добавляем обработчики событий для всех полей ввода
         document.querySelectorAll('input[type="number"]').forEach(input => {
             input.addEventListener('input', calculate);
@@ -654,3 +721,8 @@
         // Первоначальный расчет
         calculate();
         updateHistoryList();
+        updateScenarioSelect();
+        if (document.getElementById('scenario-select').options.length > 0) {
+            document.getElementById('scenario-select').value = 0;
+            loadSelectedScenario();
+        }

--- a/style.css
+++ b/style.css
@@ -368,6 +368,19 @@
             margin-bottom: 20px;
         }
 
+        .scenario-select {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 15px;
+        }
+
+        .scenario-select select {
+            flex: 1;
+            padding: 6px 8px;
+            border: 2px solid #e0e0e0;
+            border-radius: 8px;
+        }
+
         .scenario-controls {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));


### PR DESCRIPTION
## Summary
- prepopulate default scenario data on startup
- add dropdown for switching scenarios and button to save a scenario
- persist scenarios to `localStorage`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68525acb346c83268f8a40cb8e4827ab