### PR TITLE
Disable profit dynamics chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,8 +201,10 @@
 
         <div id="analytics" class="tab-content">
             <div style="padding: 25px; height: calc(100vh - 160px); overflow-y: auto;">
-                <div class="chart-container">
-                    <h3>📈 Динамика прибыли по месяцам</h3>
+                <div class="chart-container" id="profitChartContainer">
+                    <h3>📈 Динамика прибыли по месяцам
+                        <button class="btn btn-secondary" id="toggleProfitChartBtn" onclick="toggleProfitChart()" style="margin-left:10px;">Скрыть</button>
+                    </h3>
                     <div class="chart-wrapper">
                         <canvas id="profitChart"></canvas>
                     </div>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@
         // Если будут демо-данные, можно пересчитать прибыль так:
         // if (history[0]) history[0].profit = calculateMetrics(history[0].data).netProfit;
         let profitChart, funnelChart, channelsChart, scenarioChart, roiChart;
+        let profitChartVisible = true;
 
         // Загрузка сценариев из localStorage или установка значений по умолчанию
         const defaultScenarios = [
@@ -551,6 +552,27 @@
             }
         }
 
+        function toggleProfitChart() {
+            const container = document.getElementById('profitChartContainer');
+            const btn = document.getElementById('toggleProfitChartBtn');
+            if (!container || !btn) return;
+
+            if (profitChartVisible) {
+                container.style.display = 'none';
+                btn.textContent = 'Показать';
+                if (profitChart) {
+                    profitChart.destroy();
+                    profitChart = null;
+                }
+            } else {
+                container.style.display = '';
+                btn.textContent = 'Скрыть';
+                calculate();
+            }
+
+            profitChartVisible = !profitChartVisible;
+        }
+
         function saveData() {
             document.getElementById('saveModal').style.display = 'flex';
         }
@@ -781,6 +803,7 @@
 
         // Первоначальный расчет
         calculate();
+        toggleProfitChart();
         updateHistoryList();
         updateScenarioSelect();
         if (document.getElementById('scenario-select').options.length > 0) {

--- a/style.css
+++ b/style.css
@@ -59,10 +59,19 @@
             font-weight: 600;
         }
 
-        .btn-primary {
-            background: white;
-            color: #667eea;
-        }
+.btn-primary {
+    background: white;
+    color: #667eea;
+}
+
+.btn-secondary {
+    background: #e0e0e0;
+    color: #333;
+}
+
+.btn-secondary:hover {
+    background: #d5d5d5;
+}
 
         .btn-primary:hover {
             transform: translateY(-2px);


### PR DESCRIPTION
## Summary
- add toggle button for the profit chart in analytics
- implement toggleProfitChart logic and hide the graph by default
- style secondary button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68526abb79e883269e78b5e7cc6220dc